### PR TITLE
Remove unused imports from codebase

### DIFF
--- a/src/test_coverage_agent/repository/scanner.py
+++ b/src/test_coverage_agent/repository/scanner.py
@@ -1,6 +1,6 @@
 import os
 from pathlib import Path
-from typing import Dict, List, Optional, Set, Tuple
+from typing import Dict, List, Optional, Tuple
 
 
 class RepositoryScanner:

--- a/src/test_coverage_agent/repository/scanner.py
+++ b/src/test_coverage_agent/repository/scanner.py
@@ -1,6 +1,6 @@
 import os
 from pathlib import Path
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, List, Optional, Set, Tuple
 
 
 class RepositoryScanner:

--- a/src/test_coverage_agent/test_execution/test_validator.py
+++ b/src/test_coverage_agent/test_execution/test_validator.py
@@ -1,6 +1,6 @@
 import os
 import re
-from typing import Dict, List, Optional, Set, Tuple, Any
+from typing import Dict, List, Optional, Tuple, Any
 
 from langchain_core.messages import HumanMessage, SystemMessage
 

--- a/src/test_coverage_agent/ui/cli.py
+++ b/src/test_coverage_agent/ui/cli.py
@@ -1,7 +1,7 @@
 import os
 import sys
 import click
-from typing import Dict, List, Optional, Set, Tuple, Any
+from typing import Dict, List, Optional, Tuple, Any
 import json
 
 # Import necessary components

--- a/src/test_coverage_agent/ui/web.py
+++ b/src/test_coverage_agent/ui/web.py
@@ -2,7 +2,7 @@ import os
 import tempfile
 import streamlit as st
 import json
-from typing import Dict, List, Optional, Set, Tuple, Any
+from typing import Dict, List, Optional, Tuple, Any
 
 # Import necessary components
 from test_coverage_agent.repository import RepositoryScanner, TestDetector, CoverageAnalyzer

--- a/src/test_coverage_agent/ui/web_for_testing.py
+++ b/src/test_coverage_agent/ui/web_for_testing.py
@@ -1,6 +1,5 @@
 import os
-from typing import Dict, List, Optional, Set, Tuple, Any
-import json
+from typing import Dict, List, Optional, Tuple, Any
 
 # Import necessary components from the right paths
 from test_coverage_agent.repository.scanner import RepositoryScanner

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -3,7 +3,6 @@ import sys
 import pytest
 from unittest.mock import patch, MagicMock
 import streamlit as st
-import pandas as pd
 import tempfile
 
 # Mock streamlit for testing


### PR DESCRIPTION
This commit removes unused imports across several files:
- Removed 'pandas as pd' from tests/test_web.py
- Removed 'Set' import from typing in multiple files
- Removed unused 'json' import from web_for_testing.py

🤖 Generated with [Claude Code](https://claude.ai/code)